### PR TITLE
Added Syntax Highlighting to Code Editors in code-editor

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -593,3 +593,127 @@ body {
     background-color: #ffffff;
     border: none;
 }
+
+/* hey this is the highlight css */
+/* Reduce the size of the scrollbar */
+::-webkit-scrollbar {
+    width: 5px;
+    height: 5px;
+  }
+  
+  /* Style the scrollbar track */
+  ::-webkit-scrollbar-track {
+    background: #f1f1f1;
+  }
+  
+  /* Style the scrollbar thumb */
+  ::-webkit-scrollbar-thumb {
+    background: #888;
+    border-radius: 5px;
+  }
+  
+  .editWindow {
+    position: relative !important;
+    width: 100% !important;
+    height: 100% !important;
+  }
+  
+  textarea,
+  .highlighting {
+    position: absolute !important;
+    top: 0 !important;
+    left: 0 !important;
+    margin: 0 !important;
+    padding: 10px !important;
+    width: 100% !important;
+    height: 100% !important;
+    border: none !important;
+    resize: none !important;
+    overflow: auto !important;
+    white-space: nowrap !important;
+    background-color: transparent !important;
+    z-index: 1 !important;
+  }
+  textarea,
+  .highlighting,
+  .highlighting *{
+    font-size: 15px !important;
+    font-family: monospace!important;
+    line-height: 20pt!important;
+    tab-size: 2 !important;
+  }
+  textarea {
+    color: transparent;
+    background: transparent;
+    caret-color: white;
+    z-index: 1;
+  }
+  
+  .highlighting {
+    pointer-events: none;
+    z-index: 0;
+  }
+  
+  /* Highlighting styles */
+  
+  .token.comment,
+  .token.prolog,
+  .token.doctype,
+  .token.cdata {
+    color: #6c6c6c;
+  }
+  
+  .token.tag,
+  .token.attr-name,
+  .token.namespace,
+  .token.deleted {
+    color: #e2777a;
+  }
+  
+  .token.function-name {
+    color: #6196cc;
+  }
+  
+  .token.boolean,
+  .token.number,
+  .token.function {
+    color: #d19a66;
+  }
+  
+  .token.property,
+  .token.class-name,
+  .token.constant,
+  .token.symbol {
+    color: #fac863;
+  }
+  
+  .token.selector,
+  .token.important,
+  .token.atrule,
+  .token.keyword,
+  .token.builtin {
+    color: #c5a5c5;
+  }
+  
+  .token.string,
+  .token.char,
+  .token.attr-value,
+  .token.regex,
+  .token.variable {
+    color: #8dc891;
+  }
+  
+  .token.operator,
+  .token.entity,
+  .token.url {
+    color: #d4d4d4;
+  }
+  
+  .token.important,
+  .token.bold {
+    font-weight: bold;
+  }
+  
+  .token.italic {
+    font-style: italic;
+  }

--- a/index.html
+++ b/index.html
@@ -10,12 +10,18 @@
     <!-- Title -->
     <title>Code Editor</title>
     <!-- Css -->
-    <link rel="stylesheet" href="./css/style.css">
+    <link rel="stylesheet" href="./css/style.css?u;k">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/themes/prism-okaidia.min.css">
     <!-- Javascript -->
     <script defer src="./js/index.js"></script>
     <script src="https://kit.fontawesome.com/e5b27e83b5.js" crossorigin="anonymous"></script>
     <script defer src="./js/output.js"></script>
     <script defer src="./js/options.js"></script>
+    <!--cdn prism js and css-->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.23.0/prism.min.js"></script>
+    <style>
+
+    </style>
 </head>
 
 <body>
@@ -62,7 +68,8 @@
                     <div class="changeFontCont" style="display: none;" id="fixed_changeFontCont">
                         <div class="inputCont">
                             <label for="fontColor">Font Color</label>
-                            <input type="text" name="color" id="fixed_textColorInp" placeholder="Enter the color or choose it" autocomplete="off">
+                            <input type="text" name="color" id="fixed_textColorInp"
+                                placeholder="Enter the color or choose it" autocomplete="off">
                             <input type="color" id="fixed_textColorChoose">
                         </div>
                         <div class="inputCont">
@@ -72,13 +79,19 @@
                         <div class="inputCont">
                             <label for="fontFamily">Font Family</label>
                             <select id="fixed_selectFontFamily" style="font-family: 'Courier New', Courier, monospace;">
-                                <option value="'Courier New', Courier, monospace" style="font-family: 'Courier New', Courier, monospace;">Monospace</option>
-                                <option value="'Noto Sans Tagbanwa', sans-serif" style="font-family:'Noto Sans Tagbanwa', sans-serif;">Noto Sans Tagbanwa
+                                <option value="'Courier New', Courier, monospace"
+                                    style="font-family: 'Courier New', Courier, monospace;">Monospace</option>
+                                <option value="'Noto Sans Tagbanwa', sans-serif"
+                                    style="font-family:'Noto Sans Tagbanwa', sans-serif;">Noto Sans Tagbanwa
                                 </option>
-                                <option value="'Montserrat', sans-serif" style="font-family:'Montserrat', sans-serif;">Montserrat</option>
-                                <option value="'Kanit', sans-serif" style="font-family:'Kanit', sans-serif;">Kanit</option>
-                                <option value="'Fira Sans', sans-serif" style="font-family:'Fira Sans', sans-serif;">Fira Sans</option>
-                                <option value="'Hind Siliguri', sans-serif" style="font-family:'Hind Siliguri', sans-serif;">Hind Siliguri</option>
+                                <option value="'Montserrat', sans-serif" style="font-family:'Montserrat', sans-serif;">
+                                    Montserrat</option>
+                                <option value="'Kanit', sans-serif" style="font-family:'Kanit', sans-serif;">Kanit
+                                </option>
+                                <option value="'Fira Sans', sans-serif" style="font-family:'Fira Sans', sans-serif;">
+                                    Fira Sans</option>
+                                <option value="'Hind Siliguri', sans-serif"
+                                    style="font-family:'Hind Siliguri', sans-serif;">Hind Siliguri</option>
                             </select>
                         </div>
                         <div class="buttonCont">
@@ -163,7 +176,9 @@
                             </div>
                         </div>
                         <div class="editWindow">
-                            <textarea style="color: #9e9e9e; font-size: 0.9em; font-family: 'Courier New', Courier, monospace;" name="code" id="htmlCode" cols="30" rows="10"></textarea>
+                            <textarea name="code" id="htmlCode" spellcheck="false" cols="30" rows="10"></textarea>
+                            <pre class="highlighting" aria-hidden="true">
+                           <code class="language-html highlighting-content"></code></pre>
                         </div>
                     </div>
                     <div class="editinCont" id="cssContainer">
@@ -180,7 +195,10 @@
                             </div>
                         </div>
                         <div class="editWindow">
-                            <textarea style="color: #9e9e9e; font-size: 0.9em; font-family: 'Courier New', Courier, monospace;" name="code" id="cssCode" cols="30" rows="10"></textarea>
+                            <textarea
+                                name="code" id="cssCode" spellcheck="false" cols="30" rows="10"></textarea>
+                            <pre class="highlighting" aria-hidden="true"><code class="language-css highlighting-content"></code>
+                            </pre>
                         </div>
                     </div>
                     <div class="editinCont" id="jsContainer">
@@ -197,7 +215,9 @@
                             </div>
                         </div>
                         <div class="editWindow">
-                            <textarea style="color: #9e9e9e; font-size: 0.9em; font-family: 'Courier New', Courier, monospace;" name="code" id="jsCode" cols="30" rows="10"></textarea>
+                            <textarea
+                                name="code" id="jsCode" spellcheck="false" cols="30" rows="10"></textarea>
+                            <pre class="highlighting" aria-hidden="true"><code class="language-js highlighting-content"></code></pre>
                         </div>
                     </div>
                 </div>
@@ -209,5 +229,5 @@
         </div>
     </div>
 </body>
-
+<script src="./js/highlight.js"></script>
 </html>

--- a/js/highlight.js
+++ b/js/highlight.js
@@ -1,0 +1,48 @@
+let textareas = document.querySelectorAll(".editWindow textarea");
+// Add event listeners to all textareas
+textareas.forEach(textarea => {
+    let result_element = textarea.closest(".editWindow").querySelector(".highlighting-content");
+
+    textarea.addEventListener("input", function () {
+        update(textarea.value, result_element);
+    });
+    textarea.addEventListener("scroll", function () {
+        sync_scroll(textarea, result_element.closest(".highlighting"));
+    });
+    textarea.addEventListener("keydown", function (event) {
+        check_tab(textarea, event, result_element);
+    });
+});
+function update(text, element) {
+    // Handle final newlines (see article)
+    if (text[text.length - 1] == "\n") {
+        text += " ";
+    }
+    // Update code
+    element.innerHTML = text.replace(new RegExp("&", "g"), "&amp;").replace(new RegExp("<", "g"), "&lt;"); /* Global RegExp */
+    // Syntax Highlight
+    Prism.highlightElement(element);
+}
+
+function sync_scroll(textarea_element, result_element) {
+    /* Scroll result to scroll coords of event - sync with textarea */
+    // Get and set x and y
+    result_element.scrollTop = textarea_element.scrollTop;
+    result_element.scrollLeft = textarea_element.scrollLeft;
+}
+
+function check_tab(element, event, result_element) {
+    let code = element.value;
+    if (event.key == "Tab") {
+        /* Tab key pressed */
+        event.preventDefault(); // stop normal
+        let before_tab = code.slice(0, element.selectionStart); // text before tab
+        let after_tab = code.slice(element.selectionEnd, element.value.length); // text after tab
+        let cursor_pos = element.selectionStart + 1; // where cursor moves after tab - moving forward by 1 char to after tab
+        element.value = before_tab + "\t" + after_tab; // add tab char
+        // move cursor
+        element.selectionStart = cursor_pos;
+        element.selectionEnd = cursor_pos;
+        update(element.value, result_element); // Update text to include indent
+    }
+}

--- a/js/index.js
+++ b/js/index.js
@@ -321,3 +321,4 @@ function changeLayout(editorDiv_flexDirection, editor_flexDirection) {
     editor.style.flexDirection = editor_flexDirection;
     revertChanges();
 }
+


### PR DESCRIPTION
Hi there! I noticed that your repository lacked syntax highlighting for the code editors. As a solution, I have added a simple syntax highlighting feature using Prism.js. The editors now support HTML, CSS, and JavaScript syntax highlighting, making it easier for users to write and edit code.

To achieve this, I added  pre elements after textareas, and used Prism.js to highlight the code within the pre element. I also updated the CSS to ensure that the textareas and pre elements were positioned correctly and styled to match the overall design of the editors.

I hope you find this feature useful, and I would be happy to make any further adjustments or improvements based on your feedback. Thanks for maintaining this repository!